### PR TITLE
initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+  - 'stable'
+before_install:
+  - npm i -g npm@^2.0.0
+after_success:
+  - npm run semantic-release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# THIS IS WORK IN PROGRESS
+
+# hoodie-server-store
+
+> CouchDB APIs for storing JSON data and sync
+
+[![Build Status](https://travis-ci.org/hoodiehq/hoodie-server-store.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-server-store)
+[![Dependency Status](https://david-dm.org/hoodiehq/hoodie-server-store.svg)](https://david-dm.org/hoodiehq/hoodie-server-store)
+
+## Install
+
+```
+npm install --save hoodie-server-store
+```
+
+## Example
+
+```js
+var Hapi = require('hapi')
+var hapiStore = require('hoodie-server-store')
+
+var server = new Hapi.Server()
+
+server.register({
+  register: hapiStore,
+  options: {
+    couchdb: 'http://localhost:5984'
+  }
+}, function (error) {
+  if (error) throw error
+})
+
+server.connection({
+  port: 8000
+})
+server.start(function () {
+  console.log('Server running at %s', server.info.uri)
+})
+```
+
+### options.couchdb (required)
+
+Url to CouchDB
+
+```js
+options: {
+  couchdb: 'http://localhost:5984'
+}
+```
+
+### options.prefix
+
+String with which to prefix routes.
+
+```js
+options: {
+  prefix: '/my-store'
+}
+```
+
+### options.hooks
+
+Route lifecycle hooks, see http://hapijs.com/api#request-lifecycle
+
+
+```js
+options: {
+  hooks: {
+    onPreResponse: onPreResponseHandler,
+    onPreAuth: onPreAuthHandler,
+    onPostAuth: onPostAuthHandler,
+    onPreHandler: onPreHandlerHandler,
+    onPostHandler: onPostHandlerHandler,
+    onPreResponse: onPreResponseHandler
+  }
+}
+```
+
+## Local setup & tests
+
+```bash
+git clone git@github.com:hoodiehq/hoodie-server-store.git
+cd hoodie-server-store
+npm install
+npm test
+```
+
+To start the [local dev server](bin/server), run
+
+```
+npm start
+```
+
+## License
+
+MIT

--- a/index.js
+++ b/index.js
@@ -1,0 +1,18 @@
+module.exports = hapiCouchDbStore
+hapiCouchDbStore.attributes = {
+  name: 'couchdb-store'
+}
+
+function hapiCouchDbStore (server, options, next) {
+  server.register({
+    register: require('./lib/couchdb-proxy'),
+    options: {
+      couchdb: options.couchdb,
+      hooks: options.hooks
+    }
+  }, {
+    routes: {
+      prefix: options.prefix
+    }
+  }, next)
+}

--- a/lib/couchdb-proxy.js
+++ b/lib/couchdb-proxy.js
@@ -1,0 +1,39 @@
+var Joi = require('joi')
+
+module.exports = function (server, options, next) {
+  if (!options.couchdb) return next(new TypeError('options.couchdb must be set'))
+
+  server.route({
+    method: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+    path: '/{path*}',
+    handler: {
+      proxy: {
+        passThrough: true,
+        mapUri: function (request, next) {
+          var path = request.params.path || ''
+          var queryString = request.url.search || ''
+          var location = typeof options.couchdb === 'string'
+            ? options.couchdb
+            : options.couchdb.location
+          next(null, location + '/' + path + queryString)
+        }
+      }
+    },
+    config: {
+      validate: {
+        params: {
+          path: Joi.string().regex(/^[a-zA-Z]/, 'database must start with character')
+        }
+      },
+      ext: {
+      }
+    }
+  })
+
+  next()
+}
+
+module.exports.attributes = {
+  name: 'couchdb-store-proxy',
+  dependencies: 'h2o2'
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "hoodie-standalone-store",
+  "description": "CouchDB REST & front-end API",
+  "main": "index.js",
+  "bin": "bin/server",
+  "scripts": {
+    "pretest": "standard",
+    "test": "node tests | tap-spec",
+    "start": "bin/server",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hoodiehq/hoodie-standalone-store.git"
+  },
+  "keywords": [
+    "hapi",
+    "plugin",
+    "couchdb",
+    "pouchdb",
+    "hoodie"
+  ],
+  "author": "Gregor Martynus <gregor@martynus.net>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/hoodiehq/hoodie-standalone-store/issues"
+  },
+  "homepage": "https://github.com/hoodiehq/hoodie-standalone-store#readme",
+  "devDependencies": {
+    "nock": "^2.17.0",
+    "semantic-release": "^6.0.3",
+    "standard": "^5.3.1",
+    "tap": "^2.2.0",
+    "tap-spec": "^4.1.0"
+  },
+  "dependencies": {
+    "h2o2": "^4.0.1",
+    "hapi": "^11.0.2",
+    "joi": "^7.0.0"
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,71 @@
+var Hapi = require('hapi')
+var H2o2 = require('h2o2')
+var test = require('tap').test
+var Wreck = require('wreck')
+var plugin = require('../')
+
+var noop = function () {}
+
+function provisionServer () {
+  var server = new Hapi.Server()
+  server.connection()
+  server.register(H2o2, noop)
+  return server
+}
+
+test('options.couchdb is required', function (t) {
+  t.plan(2)
+
+  var server = provisionServer()
+  server.register(plugin, {}, function (error) {
+    t.ok(error instanceof TypeError, 'register fails with TypeError')
+    t.is(error.message, 'options.couchdb must be set', 'register fails with error message')
+  })
+})
+
+test('proxies request to options.couchdb', function (t) {
+  t.plan(1)
+
+  var orig = Wreck.request
+  Wreck.request = function (method, uri, options, callback) {
+    Wreck.request = orig
+    t.is(uri, 'http://example.com/foo', 'path is prefixed by http://example.com')
+  }
+
+  var server = provisionServer()
+  server.register({
+    register: plugin,
+    options: {
+      couchdb: 'http://example.com'
+    }
+  }, noop)
+
+  server.inject('/foo', noop)
+})
+
+test('adds basic auth header', function (t) {
+  t.plan(1)
+
+  var orig = Wreck.request
+  Wreck.request = function (method, uri, options, callback) {
+    Wreck.request = orig
+    t.is(options.headers.authorization, 'Basic chek12', 'sets Authorization header')
+  }
+
+  var server = provisionServer()
+  server.register({
+    register: plugin,
+    options: {
+      couchdb: {
+        location: 'http://example.com'
+      },
+      hooks: {
+        onPreAuth: function (request, next) {
+          request.headers.authorization = 'Basic chek12'
+        }
+      }
+    }
+  }, noop)
+
+  server.inject('/foo', noop)
+})


### PR DESCRIPTION
Hey Hapi experts, for the Hoodie store module, we need a proxy in front of CouchDB which we can amend with auth headers and other things. For that I'm thinking we could expose hapi's request lifesycle hooks, see the [README](https://github.com/hoodiehq/hapi-couchdb-store-api)

I don't know the hapi best pratises to implement and test this. For example, if CouchDB is not in admin party, I want the `PUT /db` and `DELETE /db` to be sent as admin, by adding the `Authorization` header with Basic auth admin credentials to the requests towards CouchDB.

I'm still new to hapi, and help would be much appreciated